### PR TITLE
feat(navbar): implement dynamic theme switching based on section back…

### DIFF
--- a/src/front/components/About/Values.jsx
+++ b/src/front/components/About/Values.jsx
@@ -102,7 +102,7 @@ export const Values = () => {
     }, [valuesData.length]);
 
     return (
-        <>
+        <div className='light-section'>
             {/* CONTENEDOR DE INTRODUCCIÓN */}
             <div className='intro-scroll-wrapper'>
                 <div className='intro-sticky-box'>
@@ -132,7 +132,7 @@ export const Values = () => {
                     </div>
                 </div>
             </div>
-        </>
+        </div>
 
 
     );

--- a/src/front/components/Navbar.jsx
+++ b/src/front/components/Navbar.jsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Link } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
 import LogoNavbar from "../assets/img/LogoNavbar.svg";
 import LogoNavMovil from "../assets/img/LogoNavMovil.svg";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,6 +13,9 @@ import { useTranslation } from "react-i18next";
 export const Navbar = () => {
 	const { t } = useTranslation();
 	const [isOpen, setIsOpen] = useState(false);
+	const [isLightMode, setIsLightMode] = useState(false);
+	const location = useLocation();
+
 	const toggleMenu = () => {
 		setIsOpen(!isOpen);
 		document.body.style.overflow = !isOpen ? 'hidden' : 'auto';
@@ -23,32 +26,75 @@ export const Navbar = () => {
 		document.body.style.overflow = 'auto';
 	};
 
+	useEffect(() => {
+		const checkNavbarColor = () => {
+			const lightSections = document.querySelectorAll(".light-section");
+			let isOverLightSection = false;
+
+			// La línea de impacto: a cuántos píxeles desde arriba quieres que detecte la colisión
+			// Si tu navbar mide ~80px de alto, 60 es un punto ideal.
+			const triggerPoint = 60;
+
+			lightSections.forEach((section) => {
+				const rect = section.getBoundingClientRect();
+
+				// Lógica de oro: Si el inicio de la sección ya subió por el trigger
+				// Y el final de la sección TODAVÍA no ha subido por el trigger...
+				if (rect.top <= triggerPoint && rect.bottom >= triggerPoint) {
+					isOverLightSection = true; // ...entonces la navbar está sobre el fondo claro
+				}
+			});
+
+			// React es inteligente: solo re-renderizará si el estado realmente cambia
+			setIsLightMode(isOverLightSection);
+		};
+
+		// 1. Al cambiar de página, le damos 50ms a React para que pinte la nueva sección antes de medir
+		const timeoutId = setTimeout(checkNavbarColor, 50);
+
+		// 2. Escuchamos el scroll de forma "pasiva" (no bloquea los fotogramas del navegador)
+		window.addEventListener("scroll", checkNavbarColor, { passive: true });
+
+		// 3. Limpiamos eventos al desmontar para evitar fugas de memoria
+		return () => {
+			clearTimeout(timeoutId);
+			window.removeEventListener("scroll", checkNavbarColor);
+		};
+
+		// Al pasar [location.pathname], obligamos al useEffect a reiniciar el radar cada que navegues a otra URL
+	}, [location.pathname]);
+
+	const textClass = isLightMode ? "dark-navbar-items" : "text-white";
+	const logoInvertClass = isLightMode ? "invert-logo-filter" : "";
+
 	return (
 		<>
 			{/* --- NAVBAR DE ESCRITORIO --- */}
 			{/* <div className="container w-100 mb-5"></div> */}
-			<nav className="navbar sticky-top navbar-expand-md d-none d-lg-block w-100 p-0 glass-effect glass-navbar">
+			<nav className={`navbar sticky-top navbar-expand-md d-none d-lg-block w-100 p-0 glass-effect glass-navbar ${isLightMode ? 'navbar-light-active' : ''}`}>
 				<div className="container px-5 py-3 d-flex justify-content-between align-items-center">
 					<Link className="navbar-brand" to="/">
-						<img src={LogoNavbar} alt="CloudTech Logo" className="h-auto w-auto" />
+						<img src={LogoNavbar} alt="CloudTech Logo" className={`h-auto w-auto ${logoInvertClass}`} />
 					</Link>
 
 					{/* <div className="d-none d-lg-flex justify-content-end w-100"> */}
 					<ul className="navbar-nav flex-row align-items-center gap-3">
 						<li className="nav-item">
-							<Link className="nav-link text-white" to="/about">{t('navbar.about')}</Link>
+							<Link className={`nav-link ${textClass}`} to="/about">{t('navbar.about')}</Link>
 						</li>
 						<li className="nav-item">
-							<Link className="nav-link text-white" to="/services">{t('navbar.services')}</Link>
+							<Link className={`nav-link ${textClass}`} to="/services">{t('navbar.services')}</Link>
 						</li>
 						<li className="nav-item">
-							<Link className="nav-link text-white" to="/projects">{t('navbar.projects')}</Link>
+							<Link className={`nav-link ${textClass}`} to="/projects">{t('navbar.projects')}</Link>
 						</li>
 						<li className="nav-item">
 							<LanguageSwitcher />
 						</li>
 						<li className="nav-item">
-							<Link className="btn btn-outline-custom-yellow rounded-pill py-2 px-4 fw-medium" to="/contact">{t('navbar.contact')}</Link>
+							<Link className={`btn ${isLightMode ? 'btn-outline-dark' : 'btn-outline-custom-yellow'} rounded-pill py-2 px-4 fw-medium`} to="/contact">
+								{t('navbar.contact')}
+							</Link>
 						</li>
 					</ul>
 					{/* </div>	 */}
@@ -58,7 +104,7 @@ export const Navbar = () => {
 			{/* --- NAVBAR MÓVIL (TRIGGER) --- */}
 			<div className="d-lg-none sticky-top w-100 glass-effect glass-mobile-navbar d-flex justify-content-between align-items-center py-3 px-4">
 				<Link className="navbar-brand" to="/" onClick={closeMenu}>
-					<img src={LogoNavbar} alt="CloudTech Logo" className="h-auto w-auto" />
+					<img src={LogoNavbar} alt="CloudTech Logo" className={`h-auto w-auto ${logoInvertClass}`} />
 				</Link>
 				<button
 					className="navbar-toggler"
@@ -66,7 +112,7 @@ export const Navbar = () => {
 					onClick={toggleMenu}
 					aria-label="Abrir menú de navegación"
 				>
-					<FontAwesomeIcon icon={faBars} className="fa-icon-yellow" size="xl" />
+					<FontAwesomeIcon icon={faBars} className={isLightMode ? "text-dark" : "fa-icon-yellow"} size="xl" />
 				</button>
 
 			</div>

--- a/src/front/components/Projects/CallToAction.jsx
+++ b/src/front/components/Projects/CallToAction.jsx
@@ -6,7 +6,7 @@ export const CallToAction = () => {
     // const { t } = useTranslation();
 
     return (
-        <section className="intro-scroll-wrapper">
+        <section className="intro-scroll-wrapper light-section">
             {/* Call to Action Section */}
             <div className="intro-sticky-box">
                 <div className="intro-content">

--- a/src/front/components/Projects/Card.jsx
+++ b/src/front/components/Projects/Card.jsx
@@ -100,7 +100,7 @@ export const Card = ({ id, cover, gallery = [], name, preview, index }) => {
                     <img
                         src={cover}
                         alt={name}
-                        className="img-fluid rounded-4 shadow-lg project-cover-img"
+                        className="img-fluid rounded-3 shadow-lg project-cover-img"
                     />
                 </Link>
             </div>

--- a/src/front/components/Services/WhereToBegin.jsx
+++ b/src/front/components/Services/WhereToBegin.jsx
@@ -70,7 +70,7 @@ export const WhereToBegin = () => {
     }, [phaseData.length]);
 
     return (
-        <>
+        <div className='light-section'>
             {/* CONTENEDOR DE INTRODUCCIÓN */}
             <div className='intro-scroll-wrapper'>
                 <div className='intro-sticky-box'>
@@ -102,6 +102,6 @@ export const WhereToBegin = () => {
                     </div>
                 </div>
             </div>
-        </>
+        </div>
     )
 }

--- a/src/front/components/Team/Card.jsx
+++ b/src/front/components/Team/Card.jsx
@@ -5,7 +5,7 @@ export const Card = ({ name, position, description, image, catImage, mailLink, l
                 <div className="card-img-wrapper overflow-hidden">
                     <img src={image} className="original-image w-100 h-100 object-fit-cover" alt="CloudTech Team member profile picture" />
                     <div
-                        className="cat-image-overlay cat-transition"
+                        className="cat-image-overlay"
                         style={{ '--cat-image-url': `url(${catImage})` }}
                     ></div>
                 </div>

--- a/src/front/index.css
+++ b/src/front/index.css
@@ -724,3 +724,15 @@ h6 {
 .container-ct-layout {
   padding: 8.3rem 0;
 }
+
+/* DARKMODE NAVBAR */
+
+.dark-navbar-items {
+  color: #04171B !important;
+  font-weight: 500 !important;
+}
+
+.invert-logo-filter {
+  filter: brightness(0) saturate(100%) invert(8%) sepia(35%) saturate(5538%) hue-rotate(181deg) brightness(96%) contrast(99%);
+  transition: filter 0.15s ease;
+}


### PR DESCRIPTION
- Integrated a passive scroll listener tracking `.light-section` containers
- Added `useLocation` hook to reset and re-trigger the radar on SPA routing
- Dynamic color switching for nav-links using custom class `.dark-navbar-items`
- Applied a precise multi-stage CSS filter to seamlessly tint the logo SVG into #04171B over light backgrounds